### PR TITLE
Fix link to documentation references

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
This pull request makes a small update to the documentation sidebar. The change corrects the filename for the "Documentation references" link to ensure it points to the correct file.

([docs/_sidebar.mdL4-R4](diffhunk://#diff-2a55b1a76ffb4ba683697763144889d5759e3f6204a8b54e94d41435523c6f97L4-R4))